### PR TITLE
#7: loading decorator improvements (closes #7)

### DIFF
--- a/src/isReady.js
+++ b/src/isReady.js
@@ -1,8 +1,7 @@
 import every from 'lodash/every';
-import map from 'lodash/map';
 
 export default ({ readyState, ...props }) => {
-  return every(map(readyState, (rs, k) => (
-    props[k] !== void 0 && typeof rs.error === 'undefined'
-  )));
+  return every(readyState, (rs, k) => (
+    props[k] !== void 0 && rs.error === void 0
+  ));
 };

--- a/src/isReady.js
+++ b/src/isReady.js
@@ -1,7 +1,0 @@
-import every from 'lodash/every';
-
-export default ({ readyState, ...props }) => {
-  return every(readyState, (rs, k) => (
-    props[k] !== void 0 && rs.error === void 0
-  ));
-};

--- a/src/loading.js
+++ b/src/loading.js
@@ -16,9 +16,10 @@ export default function loading({
   loader = <div>loading...</div>,
   loaderProps = constant({}),
   wrapperProps = constant({})
-}) { // todo `add = {}`` i.e. default empty config, so that it can be used like this: `@loading()` instead than `@loading({})`
+} = {}) {
 
   return Component => class LoadingWrapper extends React.Component {
+
     static displayName = displayName('loading')(Component);
 
     render() {

--- a/src/loading.js
+++ b/src/loading.js
@@ -26,7 +26,7 @@ export default function loading({
       const loading = isLoading(this.props);
       const readyState = { ready, loading };
       return React.cloneElement(wrapper, wrapperProps(readyState), [
-        ready && <Component {...this.props} key='content' />,
+        ready && <Component {...omit(this.props, 'readyState')} key='content' />,
         loading && React.cloneElement(loader, {
           key: 'loader', ...loaderProps(readyState)
         })

--- a/src/loading.js
+++ b/src/loading.js
@@ -5,9 +5,9 @@ import omit from 'lodash/omit';
 import constant from 'lodash/constant';
 import displayName from './displayName';
 
-const defaultIsLoading = ({ readyState }) => some(readyState, 'loading');
+export const defaultIsLoading = ({ readyState }) => some(readyState, 'loading');
 
-const defaultIsReady = ({ readyState }) => every(readyState, 'ready');
+export const defaultIsReady = ({ readyState }) => every(readyState, 'ready');
 
 export default function loading({
   isLoading = defaultIsLoading,

--- a/src/loading.js
+++ b/src/loading.js
@@ -1,21 +1,22 @@
 import React from 'react';
-import map from 'lodash/map';
+import every from 'lodash/every';
 import some from 'lodash/some';
+import omit from 'lodash/omit';
+import constant from 'lodash/constant';
 import displayName from './displayName';
-import _isReady from './isReady';
 
-const _isLoading = ({ readyState }) => {
-  return some(map(readyState, rs => rs.loading));
-};
+const defaultIsLoading = ({ readyState }) => some(readyState, 'loading');
+
+const defaultIsReady = ({ readyState }) => every(readyState, 'ready');
 
 export default function loading({
-  isLoading = _isLoading,
-  isReady = _isReady,
+  isLoading = defaultIsLoading,
+  isReady = defaultIsReady,
   wrapper = <div />,
   loader = <div>loading...</div>,
-  loaderProps = () => ({}),
-  wrapperProps = () => ({})
-}) {
+  loaderProps = constant({}),
+  wrapperProps = constant({})
+}) { // todo `add = {}`` i.e. default empty config, so that it can be used like this: `@loading()` instead than `@loading({})`
 
   return Component => class LoadingWrapper extends React.Component {
     static displayName = displayName('loading')(Component);

--- a/src/loading.js
+++ b/src/loading.js
@@ -1,3 +1,4 @@
+/* eslint-disable react/no-multi-comp */
 import React from 'react';
 import every from 'lodash/every';
 import some from 'lodash/some';
@@ -9,11 +10,14 @@ export const defaultIsLoading = ({ readyState }) => some(readyState, 'loading');
 
 export const defaultIsReady = ({ readyState }) => every(readyState, 'ready');
 
+export class NoWrapper extends React.Component { render = () => (this.props.children || [])[0] || null; }
+export class NoLoader extends React.Component { render = () => null; }
+
 export default function loading({
   isLoading = defaultIsLoading,
   isReady = defaultIsReady,
-  wrapper = <div />,
-  loader = <div>loading...</div>,
+  wrapper = <NoWrapper />,
+  loader = <NoLoader />,
   loaderProps = constant({}),
   wrapperProps = constant({})
 } = {}) {
@@ -35,3 +39,5 @@ export default function loading({
     }
   };
 }
+
+export const noLoaderLoading = loading();

--- a/src/queries.js
+++ b/src/queries.js
@@ -139,7 +139,8 @@ export default function queries(allQueries) {
                   ..._queries,
                   readyState: mapValues(_queries.readyState, (rs, queryName) => ({
                     ...rs,
-                    ready: _queries[queryName] !== void 0 && rs.error === void 0// ready if values is not undefined, and if no readyState.error
+                    // ready if values is not undefined, and if no readyState.error
+                    ready: _queries[queryName] !== void 0 && rs.error === void 0
                   }))
                 };
                 this.setState(queriesState);

--- a/src/queries.js
+++ b/src/queries.js
@@ -5,6 +5,7 @@ import shallowEqual from 'buildo-state/lib/shallowEqual'; // TODO(split)
 import connect from 'buildo-state/lib/connect'; // TODO(split)
 import some from 'lodash/some';
 import omit from 'lodash/omit';
+import mapValues from 'lodash/mapValues';
 import pick from 'lodash/pick';
 import every from 'lodash/every';
 import _displayName from './displayName';
@@ -38,7 +39,7 @@ export default function queries(allQueries) {
     const QueriesTypes = {
       readyState: t.struct(queryNames.reduce((ac, k) => ({
         ...ac, [k]: t.struct({
-          waiting: t.Boolean, fetching: t.Boolean, loading: t.Boolean, error: t.maybe(t.Any)
+          waiting: t.Boolean, fetching: t.Boolean, loading: t.Boolean, error: t.maybe(t.Any), ready: t.maybe(t.Boolean)
         })
       }), {})),
       ...queryNames.reduce((ac, k, i) => ({
@@ -104,7 +105,7 @@ export default function queries(allQueries) {
             }
             this.state = shouldBail ? {
               readyState: queryNames.reduce((ac, k) => ({ ...ac, [k]: {
-                waiting: true, loading: true, fetching: false
+                waiting: true, loading: true, fetching: false, ready: false
               } }), {})
             } : {
               ...context.avenger.queriesSync(queryNames.reduce((ac, queryName) => ({
@@ -132,7 +133,17 @@ export default function queries(allQueries) {
               }
 
               // TODO(gio): support props renaming
-              this._subscription = this.context.avenger.queries(queries).subscribe(::this.setState);
+              this._subscription = this.context.avenger.queries(queries).subscribe(q => {
+                // add `ready` boolean param to readyState
+                const queriesProps = {
+                  ...q,
+                  readyState: mapValues(q.readyState, (rs, queryName) => ({
+                    ...rs,
+                    ready: q[queryName] !== void 0 && rs.error === void 0// ready if values is not undefined, and if no readyState.error
+                  }))
+                };
+                this.setState(queriesProps);
+              });
             }
           }
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -133,16 +133,16 @@ export default function queries(allQueries) {
               }
 
               // TODO(gio): support props renaming
-              this._subscription = this.context.avenger.queries(queries).subscribe(q => {
+              this._subscription = this.context.avenger.queries(queries).subscribe(_queries => {
                 // add `ready` boolean param to readyState
-                const queriesProps = {
-                  ...q,
-                  readyState: mapValues(q.readyState, (rs, queryName) => ({
+                const queriesState = {
+                  ..._queries,
+                  readyState: mapValues(_queries.readyState, (rs, queryName) => ({
                     ...rs,
-                    ready: q[queryName] !== void 0 && rs.error === void 0// ready if values is not undefined, and if no readyState.error
+                    ready: _queries[queryName] !== void 0 && rs.error === void 0// ready if values is not undefined, and if no readyState.error
                   }))
                 };
-                this.setState(queriesProps);
+                this.setState(queriesState);
               });
             }
           }


### PR DESCRIPTION
Issue #7

## Test Plan

### tests performed
- `queries` should pass down a `readyState` object with an optional boolean `isReady` prop
- `loading` can be called without a config (i.e. `loading()` is equivalent to `loading({})`
- default wrapper is an element that renders the first children, if any
- default loader is an element that renders `null`
- default `isReady` dependes only from `readyState`
- `loading` does not pass down `readyState` to the wrapped component
