### PR TITLE
#22: queries: avoid a few "useless" rerenders debouncing avenger events (closes #22)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react": "0.14.x || 15.x"
   },
   "dependencies": {
-    "buildo-state": "^0.3.0"
+    "buildo-state": "^0.3.0",
+    "rxjs": "^5.0.3"
   }
 }

--- a/src/queries.js
+++ b/src/queries.js
@@ -8,6 +8,7 @@ import pick from 'lodash/pick';
 import every from 'lodash/every';
 import flattenDeep from 'lodash/flattenDeep';
 import _displayName from './displayName';
+import 'rxjs/add/operator/debounceTime';
 
 const log = debug('react-avenger:queries');
 const warn = debug('react-avenger:queries');
@@ -142,6 +143,7 @@ export default function queries(allQueries) {
                     ...ac, [k]: data[k].data
                   }), {})
                 }))
+                .debounceTime(5)
                 .subscribe(::this.setState);
             }
           }


### PR DESCRIPTION
Issue #22

## Test Plan

### tests performed
- tested on qia
  - you can actually see the loader and then the data in every table
  - this is particularly useful in heavy PmD
  - the overall effect for the end user is much "faster"
    - now the "click -> first render of the new view" transition is practically "istantaneous" (with just a loader), then data comes later on
     - when there's data already (from a previous cached result), container renders it async. This will be taken care of with https://github.com/buildo/react-avenger/pull/21 (not sure the overall perceived performance will be better, probably not :thinking: )