### PR TITLE
#29: use `Query.upsetParams` and `Command.invalidateParams` to produce `InputType` (closes #29)

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -47,7 +47,9 @@ export default function commands(allCommands) {
     // we can't do much better here (i.e. no `maybe`)
     // commands can have actual params that we'll never be able to retrieve
     // implicitly / before component own lifecycle
-    decorator.InputType = mapValues(CommandParamsTypes, ty => t.maybe(ty));
+    // TODO: consider doing this in react-container itself?
+    decorator.InputType = mapValues(CommandParamsTypes, t.maybe);
+
     decorator.OutputType = ids.reduce((ac, k) => ({ ...ac, [k]: t.Function }), {});
     decorator.Type = { ...decorator.InputType, ...decorator.OutputType };
 

--- a/src/commands.js
+++ b/src/commands.js
@@ -12,10 +12,6 @@ export const CommandsContextTypes = {
   commands: React.PropTypes.object
 };
 
-const commandUpsetParams = c => c.invalidateParams.reduce((ac, k) => ({
-  ...ac, [k]: t.Any // TODO: when avenger/Command api is :+1:, use the param type here
-}), {});
-
 export default function commands(allCommands) {
   return (ids) => {
     if (process.env.NODE_ENV !== 'production') {
@@ -27,7 +23,7 @@ export default function commands(allCommands) {
     }
 
     const CommandParamsTypes = ids.reduce((ac, k) => ({
-      ...ac, ...(commandUpsetParams(allCommands[k]))
+      ...ac, ...allCommands[k].invalidateParams
     }), {});
 
     const decorator = Component => {

--- a/src/queries.js
+++ b/src/queries.js
@@ -4,7 +4,7 @@ import t from 'tcomb';
 import shallowEqual from 'buildo-state/lib/shallowEqual'; // TODO(split)
 import pick from 'lodash/pick';
 import every from 'lodash/every';
-import flattenDeep from 'lodash/flattenDeep';
+import mapValues from 'lodash/mapValues';
 import _displayName from './displayName';
 import 'rxjs/add/operator/debounceTime';
 
@@ -188,7 +188,12 @@ export default function queries(allQueries) {
       };
     };
 
-    decorator.InputType = QueryParamsTypes;
+    // If params are missing queries will be bailed anyway.
+    // In this way we are not being too eager and try to "connect too much" implicitly
+    // in react-container (some params can only be passed via props by the end user)
+    // TODO: consider doing this in react-container itself?
+    decorator.InputType = mapValues(QueryParamsTypes, t.maybe);
+
     decorator.OutputType = QueriesTypes;
     decorator.Type = { ...decorator.InputType, ...decorator.OutputType };
 

--- a/src/queries.js
+++ b/src/queries.js
@@ -18,10 +18,6 @@ export const QueriesContextTypes = {
   querySync: React.PropTypes.func // not required if option `querySync=false`
 };
 
-const queryUpsetParams = q => flattenDeep(q.A).reduce((ac, k) => ({
-  ...ac, [k]: t.Any // TODO: when avenger/Query api is :+1:, use the param type here
-}), {});
-
 const mapQueriesToState = ({ data }) => ({
   readyState: {
     ...Object.keys(data).reduce((ac, k) => ({
@@ -60,7 +56,7 @@ export default function queries(allQueries) {
     }
 
     const QueryParamsTypes = queryNames.reduce((ac, queryName) => ({
-      ...ac, ...queryUpsetParams(allQueries[queryName])
+      ...ac, ...allQueries[queryName].upsetParams
     }), {});
 
     const QueriesTypes = {
@@ -70,7 +66,7 @@ export default function queries(allQueries) {
         })
       }), {})),
       ...queryNames.reduce((ac, k) => ({
-        ...ac, [k]: t.Any // TODO: when avenger/Query api is :+1:, use `returnType` here
+        ...ac, [k]: allQueries[k].returnType || t.Any
       }), {})
     };
 


### PR DESCRIPTION
Issue #29

## Test Plan

### tests performed

tested manually on gdsm and qia

### tests not performed (domain coverage)
> At times not everything can be tested, and writing what hasn't been tested is just as important as writing what has been tested.

> An example of partial test is a field displaying 4 possible values. If 3 values are tested, with screenshots, and 1 is not, then it should be mentioned here.}
