### PR TITLE
declareQueries should not accept queries returning undefined (closes #54)

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,9 @@
-import { Queries, Commands } from 'avenger';
+import { QueryReturn, Commands } from 'avenger';
 import { ObjectOmit } from 'typelevel-ts';
+
+export type mixed = object | number | string | boolean | symbol | null;
+
+type Queries = { [k: string]: QueryReturn<any, mixed> };
 
 type QueriesProps<Decl extends Queries> = { [k in keyof Decl]: Decl[k]['_A'] }[keyof Decl];
 


### PR DESCRIPTION
### tests performed

declaring a query that resolves to `undefined` yields:

```sh
      TS2345: Argument of type '{ a: QueryReturn<IOTSDictToType<{}> & IOTSDictToType<{}> & IOTSDictToType<{}>,...' is not assignable to parameter of type 'Queries'.
  Property 'a' is incompatible with index signature.
    Type 'QueryReturn<IOTSDictToType<{}> & IOTSDictToType<{}> & IOTSDictToType<{}>, T[] | undefined>' is not assignable to type 'QueryReturn<any, mixed>'.
      Type 'T[] | undefined' is not assignable to type 'mixed'.
        Type 'undefined' is not assignable to type 'mixed'.
```